### PR TITLE
refactor!: refactored rest.li client interfaces

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -10,7 +10,7 @@
     "after:bump": "npx auto-changelog -p"
   },
   "npm": {
-    "publish": true
+    "publish": false
   },
   "plugins": {
     "@release-it/conventional-changelog": {

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ const { RestliClient } = require('linkedin-api-client');
 const restliClient = new RestliClient();
 
 restliClient.get({
-  resource: '/me',
+  resourcePath: '/me',
   accessToken: <THREE_LEGGED_ACCESS_TOKEN>
 }).then(response => {
   const profile = response.data;
@@ -104,7 +104,7 @@ const { RestliClient } = require('linkedin-api-client');
 const restliClient = new RestliClient();
 
 restliClient.finder({
-  resource: '/adAccounts',
+  resourcePath: '/adAccounts',
   finderName: 'search',
   queryParams: {
     search: {
@@ -161,7 +161,8 @@ All methods of the API client require passing in a request options object, all o
 
 | Parameter | Type | Required? | Description |
 |---|---|---|---|
-| `BaseRequestOptions.resource` | String | Yes | The API resource name, which should begin with a forward slash (e.g. "/adAccounts") |
+| `BaseRequestOptions.resourcePath` | String | Yes | <p>The resource path after the base URL, beginning with a forward slash. If the path contains keys, add curly-brace placeholders for the keys and specify the path key-value map in the `pathKeys` argument.</p><p>Examples:</p><ul><li>`resourcePath: "/me"`</li><li>`resourcePath: "/adAccounts/{id}"`</li><li>`resourcePath: "/socialActions/{actionUrn}/comments/{commentId}"`</li><li>`resourcePath: "/campaignConversions/{key}`</li></ul> |
+| `BaseRequestOptions.pathKeys` | Object | No | <p>If there are path keys that are part of the `resourcePath` argument, the key placeholders must be specified in the provided `pathKeys` map. The path key values can be strings, numbers, or objects, and these will be properly encoded.</p><p>Examples:</p><ul><li>`pathKeys: {"id": 123"}`</li><li>`pathKeys: {"actionUrn":"urn:li:share:123","commentId":987`}</li><li>`pathKeys: {"key": {"campaign": "urn:li:sponsoredCampaign:123", "conversion": "urn:lla:llaPartnerConversion:456"}}`</li></ul> |
 | `BaseRequestOptions.queryParams` | Object | No | A map of query parameters. The parameter keys and values will be correctly encoded by this method, so these should not be encoded. |
 | `BaseRequestOptions.accessToken` | String | Yes | The access token that should provide the application access to the specified API |
 | `BaseRequestOptions.versionString` | String | No | An optional version string of the format "YYYYMM" or "YYYYMM.RR". If specified, the version header will be passed and the request will use the versioned APIs base URL |
@@ -180,7 +181,6 @@ Makes a Rest.li GET request to fetch the specified entity on a resource. This me
 | Parameter | Type | Required? | Description |
 |---|---|---|---|
 | `params` | Object extends [BaseRequestOptions](#base-request-options) | Yes | Standard request options |
-| `params.id` | String \|\| Number \|\| Object | No | The id or key of the entity to fetch. For simple resources, this is not specified. |
 
 **Resolved Response Object:**
 
@@ -192,8 +192,10 @@ Makes a Rest.li GET request to fetch the specified entity on a resource. This me
 **Example:**
 ```js
 restliClient.get({
-  resource: '/adAccounts',
-  id: 123,
+  resourcePath: '/adAccounts/{id}',
+  pathKeys: {
+    id: 123
+  },
   queryParams: {
     fields: 'id,name'
   },
@@ -227,7 +229,7 @@ Makes a Rest.li BATCH_GET request to fetch multiple entities on a resource. This
 **Example:**
 ```js
 restliClient.batchGet({
-  resource: '/adCampaignGroups',
+  resourcePath: '/adCampaignGroups',
   id: [123, 456, 789],
   accessToken: MY_ACCESS_TOKEN,
   versionString: '202210'
@@ -257,7 +259,7 @@ Makes a Rest.li GET_ALL request to fetch all entities on a resource.
 **Example:**
 ```js
 restliClient.getAll({
-  resource: '/fieldsOfStudy',
+  resourcePath: '/fieldsOfStudy',
   queryParams: {
     start: 0,
     count: 15
@@ -292,7 +294,7 @@ Makes a Rest.li FINDER request to find entities by some specified criteria.
 **Example:**
 ```js
 restliClient.finder({
-  resource: '/adAccounts',
+  resourcePath: '/adAccounts',
   finderName: 'search'
   queryParams: {
     search: {
@@ -322,7 +324,8 @@ Makes a Rest.li BATCH_FINDER request to find entities by multiple sets of criter
 | Parameter | Type | Required? | Description |
 |---|---|---|---|
 | `params` | Object extends [BaseRequestOptions](#base-request-options) | Yes | Standard request options |
-| `params.batchFinderName` | String | Yes | The Rest.li batch finder name. This will be included in the request query parameters. |
+| `params.finderName` | String | Yes | The Rest.li batch finder name. This will be included in the request query parameters. |
+| `params.finderCriteria` | Object | Yes | An object with `name` and `value` properties, representing the required batch finder criteria information. `name` should be the batch finder criteria parameter name, and `value` should be a list of finder param objects. The batch finder results are correspondingly ordered according to this list. The batch finder criteria will be encoded and added to the request query parameters. |
 
 **Resolved Response Object:**
 
@@ -340,9 +343,10 @@ Makes a Rest.li BATCH_FINDER request to find entities by multiple sets of criter
 ```js
 restliClient.batchFinder({
   resource: '/organizationAuthorizations',
-  batchFinderName: 'authorizationActionsAndImpersonator'
-  queryParams: {
-    authorizationActions: [
+  finderName: 'authorizationActionsAndImpersonator'
+  finderCriteria: {
+    name: 'authorizationActions',
+    value: [
       {
         'OrganizationRoleAuthorizationAction': {
           actionType: 'ADMINISTRATOR_READ'
@@ -383,7 +387,7 @@ Makes a Rest.li CREATE request to create a new entity on the resource.
 **Example:**
 ```js
 restliClient.create({
-  resource: '/adAccountsV2',
+  resourcePath: '/adAccountsV2',
   entity: {
     name: 'Test Ad Account',
     type: 'BUSINESS',
@@ -419,7 +423,7 @@ Makes a Rest.li BATCH_CREATE request to create multiple entities in a single cal
 **Example:**
 ```js
 restliClient.batchCreate({
-  resource: '/adCampaignGroups',
+  resourcePath: '/adCampaignGroups',
   entities: [
     {
       account: 'urn:li:sponsoredAccount:111',
@@ -448,7 +452,6 @@ Makes a Rest.li UPDATE request to update an entity (overwriting the entire entit
 | Parameter | Type | Required? | Description |
 |---|---|---|---|
 | `params` | Object extends [BaseRequestOptions](#base-request-options) | Yes | Standard request options |
-| `params.id` | String \|\| Number \|\| Object | Yes | The id or key of the entity to update. For simple resources, this is not specified. |
 | `params.entity` | Object | Yes | The value of the entity with updated values. |
 
 **Resolved Response Object:**
@@ -460,10 +463,12 @@ Makes a Rest.li UPDATE request to update an entity (overwriting the entire entit
 **Example:**
 ```js
 restliClient.update({
-  resource: '/adAccountUsers',
-  id: {
-    account: 'urn:li:sponsoredAccount:123',
-    user: 'urn:li:person:foobar'
+  resourcePath: '/adAccountUsers/{key}',
+  pathKeys: {
+    key: {
+      account: 'urn:li:sponsoredAccount:123',
+      user: 'urn:li:person:foobar'
+    }
   },
   entity: {
     account: 'urn:li:sponsoredAccount:123',
@@ -498,7 +503,7 @@ Makes a Rest.li BATCH_UPDATE request to update multiple entities in a single cal
 **Example:**
 ```js
 restliClient.batchUpdate({
-  resource: '/campaignConversions',
+  resourcePath: '/campaignConversions',
   ids: [
     { campaign: 'urn:li:sponsoredCampaign:123', conversion: 'urn:lla:llaPartnerConversion:456' },
     { campaign: 'urn:li:sponsoredCampaign:123', conversion: 'urn:lla:llaPartnerConversion:789' }
@@ -524,7 +529,6 @@ When an entity has nested fields that can be modified, passing in the original a
 | Parameter | Type | Required? | Description |
 |---|---|---|---|
 | `params` | Object extends [BaseRequestOptions](#base-request-options) | Yes | Standard request options |
-| `params.id` | String \|\| Number \|\| Object | No | The id or key of the entity to update. For simple resources, this is not specified. |
 | `params.patchSetObject` | Object | No | The value of the entity with only the modified fields present. If specified, this will be directly sent as the patch object. |
 | `params.originalEntity` | Object | No | The value of the original entity. If specified and `patchSetObject` is not provided, this will be used in conjunction with `modifiedEntity` to compute the patch object. |
 | `params.modifiedEntity` | Object | No | The value of the modified entity. If specified and `patchSetObject` is not provided, this will be used in conjunction with `originalEntity` to compute the patch object. |
@@ -538,8 +542,10 @@ When an entity has nested fields that can be modified, passing in the original a
 **Example:**
 ```js
 restliClient.partialUpdate({
-  resource: '/adAccounts',
-  id: 123,
+  resourcePath: '/adAccounts/{id}',
+  pathKeys: {
+    id: 123
+  },
   patchSetObject: {
     name: 'TestAdAccountModified',
     reference: 'urn:li:organization:456'
@@ -576,7 +582,7 @@ Makes a Rest.li BATCH_PARTIAL_UPDATE request to partially update multiple entite
 **Example:**
 ```js
 restliClient.batchPartialUpdate({
-  resource: '/adCampaignGroups',
+  resourcePath: '/adCampaignGroups',
   id: [123, 456],
   patchSetObjects: [
     { status: 'ACTIVE' },
@@ -603,7 +609,6 @@ Makes a Rest.li DELETE request to delete an entity.
 | Parameter | Type | Required? | Description |
 |---|---|---|---|
 | `params` | Object extends [BaseRequestOptions](#base-request-options) | Yes | Standard request options |
-| `params.id` | String \|\| Number \|\| Object | No | The id or key of the entity to delete. For simple resources, this is not specified. |
 
 **Resolved Response Object:**
 
@@ -614,8 +619,10 @@ Makes a Rest.li DELETE request to delete an entity.
 **Example:**
 ```js
 restliClient.delete({
-  resource: '/adAccounts',
-  id: 123,
+  resourcePath: '/adAccounts/{id}',
+  pathKeys: {
+    id: 123
+  },
   versionString: '202210',
   accessToken: MY_ACCESS_TOKEN
 }).then(response => {
@@ -645,7 +652,7 @@ Makes a Rest.li BATCH_DELETE request to delete multiple entities at once.
 **Example:**
 ```js
 restliClient.batchDelete({
-  resource: '/adAccounts',
+  resourcePath: '/adAccounts',
   ids: [123, 456],
   versionString: '202210',
   accessToken: MY_ACCESS_TOKEN
@@ -676,7 +683,7 @@ Makes a Rest.li ACTION request to perform an action on a specified resource.
 **Example:**
 ```js
 restliClient.action({
-  resource: '/testResource',
+  resourcePath: '/testResource',
   actionName: 'doSomething',
   accessToken: MY_ACCESS_TOKEN
 }).then(response => {

--- a/examples/batch-get-campaign-groups-query-tunneling.ts
+++ b/examples/batch-get-campaign-groups-query-tunneling.ts
@@ -25,18 +25,24 @@ async function main(): Promise<void> {
    * Randomly generate campaign group ids and send in a BATCH_GET request (we expect all 404 responses).
    * The client should automatically do query tunneling and perform a POST request.
    */
-  const campaignGroupIds = Array.from({ length: NUMBER_OF_ENTITIES }).map(_ => Math.floor(Math.random() * 99999999999999));
+  const campaignGroupIds = Array.from({ length: NUMBER_OF_ENTITIES }).map((_) =>
+    Math.floor(Math.random() * 99999999999999)
+  );
   const batchGetResponse = await restliClient.batchGet({
-    resource: AD_CAMPAIGN_GROUPS_RESOURCE,
+    resourcePath: AD_CAMPAIGN_GROUPS_RESOURCE,
     ids: campaignGroupIds,
     accessToken,
     versionString: MDP_VERSION
   });
-  console.log(`Successfully made a BATCH_GET request on /adCampaignGroups. HTTP Method: ${batchGetResponse.config.method}]`);
+  console.log(
+    `Successfully made a BATCH_GET request on /adCampaignGroups. HTTP Method: ${batchGetResponse.config.method}]`
+  );
 }
 
-main().then(() => {
-  console.log('Completed');
-}).catch((error) => {
-  console.log(`Error encountered: ${error.message}`);
-});
+main()
+  .then(() => {
+    console.log('Completed');
+  })
+  .catch((error) => {
+    console.log(`Error encountered: ${error.message}`);
+  });

--- a/examples/crud-ad-accounts.ts
+++ b/examples/crud-ad-accounts.ts
@@ -11,6 +11,7 @@ dotenv.config();
 
 const MDP_VERSION = '202212';
 const AD_ACCOUNTS_RESOURCE = '/adAccounts';
+const AD_ACCOUNTS_ENTITY_RESOURCE = '/adAccounts/{id}';
 
 async function main(): Promise<void> {
   const restliClient = new RestliClient();
@@ -21,7 +22,7 @@ async function main(): Promise<void> {
    * Create a test ad account
    */
   const createResponse = await restliClient.create({
-    resource: AD_ACCOUNTS_RESOURCE,
+    resourcePath: AD_ACCOUNTS_RESOURCE,
     entity: {
       name: 'Test Ad Account',
       reference: 'urn:li:organization:123',
@@ -33,38 +34,42 @@ async function main(): Promise<void> {
     versionString: MDP_VERSION
   });
   const adAccountId = createResponse.createdEntityId as string;
-  console.log(`Successfully created ad account: ${adAccountId}`);
+  console.log(`Successfully created ad account: ${adAccountId}\n`);
 
   /**
    * Get the created ad account
    */
   const getResponse = await restliClient.get({
-    resource: AD_ACCOUNTS_RESOURCE,
-    id: adAccountId,
+    resourcePath: AD_ACCOUNTS_ENTITY_RESOURCE,
+    pathKeys: {
+      id: adAccountId
+    },
     accessToken,
     versionString: MDP_VERSION
   });
-  console.log(`Successfully fetched ad acccount: ${JSON.stringify(getResponse.data, null, 2)}`);
+  console.log(`Successfully fetched ad acccount: ${JSON.stringify(getResponse.data, null, 2)}\n`);
 
   /**
    * Partial update on ad account
    */
   await restliClient.partialUpdate({
-    resource: AD_ACCOUNTS_RESOURCE,
-    id: adAccountId,
+    resourcePath: AD_ACCOUNTS_ENTITY_RESOURCE,
+    pathKeys: {
+      id: adAccountId
+    },
     patchSetObject: {
       name: 'Modified Test Ad Account'
     },
     accessToken,
     versionString: MDP_VERSION
   });
-  console.log('Successfully did partial update of ad account');
+  console.log('Successfully did partial update of ad account\n');
 
   /**
    * Find all ad accounts according to a specified search criteria
    */
   const finderResponse = await restliClient.finder({
-    resource: AD_ACCOUNTS_RESOURCE,
+    resourcePath: AD_ACCOUNTS_RESOURCE,
     finderName: 'search',
     queryParams: {
       search: {
@@ -80,22 +85,28 @@ async function main(): Promise<void> {
     accessToken,
     versionString: MDP_VERSION
   });
-  console.log(`Successfully searched ad accounts: ${JSON.stringify(finderResponse.data.elements, null, 2)}`);
+  console.log(
+    `Successfully searched ad accounts: ${JSON.stringify(finderResponse.data.elements, null, 2)}\n`
+  );
 
   /**
    * Delete ad account
    */
   await restliClient.delete({
-    resource: AD_ACCOUNTS_RESOURCE,
-    id: adAccountId,
+    resourcePath: AD_ACCOUNTS_ENTITY_RESOURCE,
+    pathKeys: {
+      id: adAccountId
+    },
     accessToken,
     versionString: MDP_VERSION
   });
-  console.log('Successfully deleted ad account');
+  console.log('Successfully deleted ad account\n');
 }
 
-main().then(() => {
-  console.log('Completed');
-}).catch((error) => {
-  console.log(`Error encountered: ${error.message}`);
-});
+main()
+  .then(() => {
+    console.log('Completed');
+  })
+  .catch((error) => {
+    console.log(`Error encountered: ${error.message}`);
+  });

--- a/examples/get-profile.ts
+++ b/examples/get-profile.ts
@@ -18,7 +18,7 @@ async function main(): Promise<void> {
    * Basic usage
    */
   let response = await restliClient.get({
-    resource: '/me',
+    resourcePath: '/me',
     accessToken
   });
   console.log('Basic usage:', response.data);
@@ -27,7 +27,7 @@ async function main(): Promise<void> {
    * With field projection to limit fields returned
    */
   response = await restliClient.get({
-    resource: '/me',
+    resourcePath: '/me',
     queryParams: {
       fields: 'id,firstName,lastName'
     },
@@ -39,7 +39,7 @@ async function main(): Promise<void> {
    * With decoration of displayImage
    */
   response = await restliClient.get({
-    resource: '/me',
+    resourcePath: '/me',
     queryParams: {
       projection: '(id,firstName,lastName,profilePicture(displayImage~:playableStreams))'
     },
@@ -48,8 +48,10 @@ async function main(): Promise<void> {
   console.log('With decoration:', response.data);
 }
 
-main().then(() => {
-  console.log('Completed');
-}).catch((error) => {
-  console.log(`Error encountered: ${error.message}`);
-});
+main()
+  .then(() => {
+    console.log('Completed');
+  })
+  .catch((error) => {
+    console.log(`Error encountered: ${error.message}`);
+  });

--- a/examples/oauth-member-auth-redirect.ts
+++ b/examples/oauth-member-auth-redirect.ts
@@ -45,12 +45,12 @@ restliClient.setDebugParams({ enabled: true });
 app.get('/', (_req, res) => {
   if (!accessToken) {
     // If no access token, have member authorize again
-    res.redirect(authClient.generateMemberAuthorizationUrl(['r_liteprofile', 'r_ads']));
+    res.redirect(authClient.generateMemberAuthorizationUrl(['r_liteprofile', 'rw_ads']));
   } else {
     // Fetch profile details
     restliClient
       .get({
-        resource: '/me',
+        resourcePath: '/me',
         accessToken
       })
       .then((response) => {
@@ -71,6 +71,7 @@ app.get('/oauth', (req, res) => {
       .exchangeAuthCodeForAccessToken(authCode)
       .then((response) => {
         accessToken = response.access_token;
+        console.log(`Access token: ${accessToken}`);
         res.redirect('/');
       })
       .catch(() => {

--- a/examples/retry-and-interceptors.ts
+++ b/examples/retry-and-interceptors.ts
@@ -24,7 +24,7 @@ async function main(): Promise<void> {
   /**
    * Configure a custom request interceptor
    */
-  restliClient.axiosInstance.interceptors.request.use(function(req) {
+  restliClient.axiosInstance.interceptors.request.use(function (req) {
     // @ts-expect-error
     if (req['axios-retry'].retryCount === 2) {
       // On the second retry, remove the invalid query parameter so request will be successful
@@ -36,19 +36,24 @@ async function main(): Promise<void> {
   /**
    * Configure a custom response interceptor.
    */
-  restliClient.axiosInstance.interceptors.response.use(function(res) {
-    console.log('Hit custom response interceptor.');
-    return res;
-  }, async function(error) {
-    /**
-     * Resetting the config headers is a necessary workaround for retrying the request correctly.
-     * See axios issue here: https://github.com/axios/axios/issues/5089
-     */
-    const config = error.config;
-    config.headers = JSON.parse(JSON.stringify(config.headers || {}));
-    console.log(`Hit custom error response interceptor. Retry count: ${config['axios-retry'].retryCount}`);
-    return await Promise.reject(error);
-  });
+  restliClient.axiosInstance.interceptors.response.use(
+    function (res) {
+      console.log('Hit custom response interceptor.');
+      return res;
+    },
+    async function (error) {
+      /**
+       * Resetting the config headers is a necessary workaround for retrying the request correctly.
+       * See axios issue here: https://github.com/axios/axios/issues/5089
+       */
+      const config = error.config;
+      config.headers = JSON.parse(JSON.stringify(config.headers || {}));
+      console.log(
+        `Hit custom error response interceptor. Retry count: ${config['axios-retry'].retryCount}`
+      );
+      return await Promise.reject(error);
+    }
+  );
 
   /**
    * Use the axios-retry library to configure retry condition, exponential retry
@@ -72,7 +77,7 @@ async function main(): Promise<void> {
    * request interceptors.
    */
   const response = await restliClient.get({
-    resource: '/me',
+    resourcePath: '/me',
     queryParams: {
       invalidParam: true
     },
@@ -81,8 +86,10 @@ async function main(): Promise<void> {
   console.log(response.data);
 }
 
-main().then(() => {
-  console.log('Completed');
-}).catch((error) => {
-  console.log(`Error encountered: ${error.message}`);
-});
+main()
+  .then(() => {
+    console.log('Completed');
+  })
+  .catch((error) => {
+    console.log(`Error encountered: ${error.message}`);
+  });

--- a/lib/utils/api-utils.ts
+++ b/lib/utils/api-utils.ts
@@ -3,10 +3,44 @@
  */
 
 import { VERSIONED_BASE_URL, NON_VERSIONED_BASE_URL, HEADERS } from './constants';
+import { encode } from './encoder';
 import { version } from '../../package.json';
 
-export function getRestApiBaseUrl(versionString?: string | null) {
-  return versionString ? VERSIONED_BASE_URL : NON_VERSIONED_BASE_URL;
+/**
+ * Method to build the URL (not including query parameters) for a REST-based API call to LinkedIn
+ */
+export function buildRestliUrl(
+  resourcePath: string,
+  pathKeys: Record<string, any> = null,
+  versionString?: string
+): string {
+  const baseUrl = versionString ? VERSIONED_BASE_URL : NON_VERSIONED_BASE_URL;
+  pathKeys = pathKeys || {};
+
+  const PLACEHOLDER_REGEX = /\{\w+\}/g;
+  // Validate resourcePath and pathKeys
+  const placeholderMatches = resourcePath.match(PLACEHOLDER_REGEX);
+  const numPlaceholders = placeholderMatches ? placeholderMatches.length : 0;
+
+  if (numPlaceholders !== Object.keys(pathKeys).length) {
+    throw new Error(
+      `The number of placeholders in the resourcePath (${resourcePath}) does not match the number of entries in the pathKeys argument`
+    );
+  }
+
+  const resourcePathWithKeys = resourcePath.replace(PLACEHOLDER_REGEX, (match) => {
+    // match looks like "{id}", so remove the curly braces to get the placeholder
+    const placeholder = match.substring(1, match.length - 1);
+    if (Object.prototype.hasOwnProperty.call(pathKeys, placeholder)) {
+      return encode(pathKeys[placeholder]);
+    } else {
+      throw new Error(
+        `The placeholder ${match} was found in resourcePath, which does not have a corresponding entry in pathKeys`
+      );
+    }
+  });
+
+  return `${baseUrl}${resourcePathWithKeys}`;
 }
 
 export function getRestliRequestHeaders({
@@ -21,7 +55,7 @@ export function getRestliRequestHeaders({
   versionString?: string | null;
   httpMethodOverride?: string;
   contentType?: string;
-}) {
+}): Record<string, any> {
   const headers = {
     [HEADERS.CONNECTION]: 'Keep-Alive',
     [HEADERS.RESTLI_PROTOCOL_VERSION]: '2.0.0',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "linkedin-api-client",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "url": "https://github.com/linkedin-developers/linkedin-api-js-client.git"
   },
   "license": "SEE LICENSE IN LICENSE.md",
+  "engines": {
+    "node": ">=14.0.0"
+  },
   "dependencies": {
     "axios": "^1.1.3",
     "lodash": "^4.17.21",

--- a/tests/restli-client.test.ts
+++ b/tests/restli-client.test.ts
@@ -42,8 +42,10 @@ describe('RestliClient', () => {
       description: 'Get request for a non-versioned collection resource',
       inputRequestRestliMethod: 'GET',
       inputRequestOptions: {
-        resource: '/adAccounts',
-        id: 123,
+        resourcePath: '/adAccounts/{id}',
+        pathKeys: {
+          id: 123
+        },
         accessToken: TEST_BEARER_TOKEN
       },
       inputResponse: {
@@ -59,7 +61,7 @@ describe('RestliClient', () => {
       description: 'Get request for a simple resource',
       inputRequestRestliMethod: 'GET',
       inputRequestOptions: {
-        resource: '/me',
+        resourcePath: '/me',
         accessToken: TEST_BEARER_TOKEN
       },
       inputResponse: {
@@ -75,8 +77,10 @@ describe('RestliClient', () => {
       description: 'Get request for versioned collection resource',
       inputRequestRestliMethod: 'GET',
       inputRequestOptions: {
-        resource: '/adAccounts',
-        id: 123,
+        resourcePath: '/adAccounts/{id}',
+        pathKeys: {
+          id: 123
+        },
         versionString: '202209',
         accessToken: TEST_BEARER_TOKEN
       },
@@ -96,8 +100,10 @@ describe('RestliClient', () => {
       description: 'Get request with complex key and query parameters',
       inputRequestRestliMethod: 'GET',
       inputRequestOptions: {
-        resource: '/accountRoles',
-        id: { member: 'urn:li:person:123', account: 'urn:li:account:234' },
+        resourcePath: '/accountRoles/{key}',
+        pathKeys: {
+          key: { member: 'urn:li:person:123', account: 'urn:li:account:234' }
+        },
         queryParams: {
           param1: 'foobar',
           param2: { prop1: 'abc', prop2: 'def' }
@@ -117,7 +123,7 @@ describe('RestliClient', () => {
       description: 'Get request with field projections',
       inputRequestRestliMethod: 'GET',
       inputRequestOptions: {
-        resource: '/me',
+        resourcePath: '/me',
         queryParams: {
           fields: 'id,firstName,lastName',
           otherParam: [1, 2, 3]
@@ -137,8 +143,10 @@ describe('RestliClient', () => {
       description: 'Get request with error response',
       inputRequestRestliMethod: 'GET',
       inputRequestOptions: {
-        resource: '/adAccounts',
-        id: 123,
+        resourcePath: '/adAccounts/{id}',
+        pathKeys: {
+          id: 123
+        },
         accessToken: TEST_BEARER_TOKEN
       },
       inputResponse: {
@@ -159,8 +167,10 @@ describe('RestliClient', () => {
       description: 'Get request with query tunneling',
       inputRequestRestliMethod: 'GET',
       inputRequestOptions: {
-        resource: '/adAccounts',
-        id: 123,
+        resourcePath: '/adAccounts/{id}',
+        pathKeys: {
+          id: 123
+        },
         queryParams: {
           longParam: LONG_STRING
         },
@@ -189,7 +199,7 @@ describe('RestliClient', () => {
       description: 'Batch get request for a non-versioned collection resource',
       inputRequestRestliMethod: 'BATCH_GET',
       inputRequestOptions: {
-        resource: '/testResource',
+        resourcePath: '/testResource',
         ids: [123, 456, 789],
         accessToken: TEST_BEARER_TOKEN
       },
@@ -212,7 +222,7 @@ describe('RestliClient', () => {
       description: 'Batch get request with complex key and query parameters',
       inputRequestRestliMethod: 'BATCH_GET',
       inputRequestOptions: {
-        resource: '/testResource',
+        resourcePath: '/testResource',
         ids: [
           { member: 'urn:li:person:123', account: 'urn:li:account:234' },
           { member: 'urn:li:person:234', account: 'urn:li:account:345' },
@@ -244,7 +254,7 @@ describe('RestliClient', () => {
       description: 'Batch get request with error response',
       inputRequestRestliMethod: 'BATCH_GET',
       inputRequestOptions: {
-        resource: '/testResource',
+        resourcePath: '/testResource',
         ids: [123, 456, 789],
         accessToken: TEST_BEARER_TOKEN
       },
@@ -266,7 +276,7 @@ describe('RestliClient', () => {
       description: 'Batch get request with query tunneling',
       inputRequestRestliMethod: 'BATCH_GET',
       inputRequestOptions: {
-        resource: '/testResource',
+        resourcePath: '/testResource',
         ids: [123, 456, 789],
         queryParams: {
           longParam: LONG_STRING
@@ -302,8 +312,7 @@ describe('RestliClient', () => {
       description: 'Get all request for a non-versioned collection resource',
       inputRequestRestliMethod: 'GET_ALL',
       inputRequestOptions: {
-        resource: '/testResource',
-
+        resourcePath: '/testResource',
         accessToken: TEST_BEARER_TOKEN
       },
       inputResponse: {
@@ -325,7 +334,7 @@ describe('RestliClient', () => {
       description: 'Create request for a non-versioned resource',
       inputRequestRestliMethod: 'CREATE',
       inputRequestOptions: {
-        resource: '/testResource',
+        resourcePath: '/testResource',
         entity: {
           name: 'TestApp1'
         },
@@ -354,7 +363,7 @@ describe('RestliClient', () => {
       description: 'Batch create request for a non-versioned resource',
       inputRequestRestliMethod: 'BATCH_CREATE',
       inputRequestOptions: {
-        resource: '/adCampaignGroups',
+        resourcePath: '/adCampaignGroups',
         entities: [
           {
             account: 'urn:li:sponsoredAccount:111',
@@ -398,8 +407,10 @@ describe('RestliClient', () => {
       description: 'Partial update using original/modified entity',
       inputRequestRestliMethod: 'PARTIAL_UPDATE',
       inputRequestOptions: {
-        resource: '/testResource',
-        id: 123,
+        resourcePath: '/testResource/{id}',
+        pathKeys: {
+          id: 123
+        },
         originalEntity: {
           name: 'TestApp1',
           organization: 'urn:li:organization:123',
@@ -433,8 +444,10 @@ describe('RestliClient', () => {
       description: 'Partial update using patchSetObject',
       inputRequestRestliMethod: 'PARTIAL_UPDATE',
       inputRequestOptions: {
-        resource: '/testResource',
-        id: 123,
+        resourcePath: '/testResource/{id}',
+        pathKeys: {
+          id: 123
+        },
         patchSetObject: {
           organization: 'urn:li:organization:123',
           description: 'foobar'
@@ -466,7 +479,7 @@ describe('RestliClient', () => {
       description: 'Batch partial update using original/modified entities',
       inputRequestRestliMethod: 'BATCH_PARTIAL_UPDATE',
       inputRequestOptions: {
-        resource: '/testResource',
+        resourcePath: '/testResource',
         ids: ['urn:li:person:123', 'urn:li:person:456'],
         originalEntities: [
           {
@@ -530,7 +543,7 @@ describe('RestliClient', () => {
       description: 'Batch partial update using patchSetObjects',
       inputRequestRestliMethod: 'BATCH_PARTIAL_UPDATE',
       inputRequestOptions: {
-        resource: '/testResource',
+        resourcePath: '/testResource',
         ids: ['urn:li:person:123', 'urn:li:person:456'],
         patchSetObjects: [
           {
@@ -584,7 +597,7 @@ describe('RestliClient', () => {
       description: 'Update a simple non-versioned resource',
       inputRequestRestliMethod: 'UPDATE',
       inputRequestOptions: {
-        resource: '/testResource',
+        resourcePath: '/testResource',
         entity: {
           name: 'Steven',
           description: 'foobar'
@@ -608,10 +621,12 @@ describe('RestliClient', () => {
       description: 'Update an entity on an versioned, association resource',
       inputRequestRestliMethod: 'UPDATE',
       inputRequestOptions: {
-        resource: '/testResource',
-        id: {
-          application: 'urn:li:developerApplication:123',
-          member: 'urn:li:member:456'
+        resourcePath: '/testResource/{key}',
+        pathKeys: {
+          key: {
+            application: 'urn:li:developerApplication:123',
+            member: 'urn:li:member:456'
+          }
         },
         entity: {
           name: 'Steven',
@@ -644,7 +659,7 @@ describe('RestliClient', () => {
       description: 'Batch update on versioned resource',
       inputRequestRestliMethod: 'BATCH_UPDATE',
       inputRequestOptions: {
-        resource: '/testResource',
+        resourcePath: '/testResource',
         ids: [
           {
             application: 'urn:li:developerApplication:123',
@@ -696,7 +711,7 @@ describe('RestliClient', () => {
       description: 'Delete on a simple resource',
       inputRequestRestliMethod: 'DELETE',
       inputRequestOptions: {
-        resource: '/testResource',
+        resourcePath: '/testResource',
         accessToken: TEST_BEARER_TOKEN
       },
       inputResponse: {
@@ -712,8 +727,10 @@ describe('RestliClient', () => {
       description: 'Delete on a collection resource',
       inputRequestRestliMethod: 'DELETE',
       inputRequestOptions: {
-        resource: '/testResource',
-        id: 123,
+        resourcePath: '/testResource/{id}',
+        pathKeys: {
+          id: 123
+        },
         accessToken: TEST_BEARER_TOKEN
       },
       inputResponse: {
@@ -733,7 +750,7 @@ describe('RestliClient', () => {
       description: 'Batch delete on a non-versioned resource',
       inputRequestRestliMethod: 'BATCH_DELETE',
       inputRequestOptions: {
-        resource: '/testResource',
+        resourcePath: '/testResource',
         ids: ['urn:li:member:123', 'urn:li:member:456'],
         accessToken: TEST_BEARER_TOKEN
       },
@@ -756,7 +773,7 @@ describe('RestliClient', () => {
       description: 'Finder on a non-versioned resource',
       inputRequestRestliMethod: 'FINDER',
       inputRequestOptions: {
-        resource: '/testResource',
+        resourcePath: '/testResource',
         finderName: 'search',
         queryParams: {
           search: {
@@ -786,10 +803,11 @@ describe('RestliClient', () => {
       description: 'Batch finder on a non-versioned resource',
       inputRequestRestliMethod: 'BATCH_FINDER',
       inputRequestOptions: {
-        resource: '/testResource',
-        batchFinderName: 'authActions',
-        queryParams: {
-          authActionsCriteria: [
+        resourcePath: '/testResource',
+        finderName: 'authActions',
+        finderCriteria: {
+          name: 'authActionsCriteria',
+          value: [
             {
               OrgRoleAuthAction: {
                 actionType: 'ADMIN_READ'
@@ -823,7 +841,7 @@ describe('RestliClient', () => {
       description: 'Action on a non-versioned resource',
       inputRequestRestliMethod: 'ACTION',
       inputRequestOptions: {
-        resource: '/testResource',
+        resourcePath: '/testResource',
         actionName: 'doSomething',
         data: {
           additionalParam: 123
@@ -908,7 +926,7 @@ describe('RestliClient', () => {
 
     // Test initial state where logging is disabled
     await restliClient.get({
-      resource: '/test',
+      resourcePath: '/test',
       accessToken: 'ABC123'
     });
 
@@ -922,7 +940,7 @@ describe('RestliClient', () => {
     restliClient.setDebugParams({ enabled: true, logSuccessResponses: true });
 
     await restliClient.get({
-      resource: '/test',
+      resourcePath: '/test',
       accessToken: 'ABC123'
     });
 
@@ -936,7 +954,7 @@ describe('RestliClient', () => {
 
     try {
       await restliClient.get({
-        resource: '/test',
+        resourcePath: '/test',
         accessToken: 'ABC123'
       });
       fail('RestliClient should have thrown an error.');

--- a/tests/utils/api-utils.test.ts
+++ b/tests/utils/api-utils.test.ts
@@ -1,10 +1,48 @@
-import { getRestApiBaseUrl, getRestliRequestHeaders } from '../../lib/utils/api-utils';
+import { buildRestliUrl, getRestliRequestHeaders } from '../../lib/utils/api-utils';
 import { version } from '../../package.json';
 
 describe('api-utils', () => {
-  test('getRestApiBaseUrl', () => {
-    expect(getRestApiBaseUrl()).toBe('https://api.linkedin.com/v2');
-    expect(getRestApiBaseUrl('202209')).toBe('https://api.linkedin.com/rest');
+  test.each([
+    {
+      resourcePath: '/adAccounts',
+      pathKeys: null,
+      versionString: null,
+      expectedUrl: 'https://api.linkedin.com/v2/adAccounts'
+    },
+    {
+      resourcePath: '/adAccounts',
+      pathKeys: null,
+      versionString: '202209',
+      expectedUrl: 'https://api.linkedin.com/rest/adAccounts'
+    },
+    {
+      resourcePath: '/adAccounts/{id}',
+      pathKeys: {
+        id: 123
+      },
+      versionString: '202209',
+      expectedUrl: 'https://api.linkedin.com/rest/adAccounts/123'
+    },
+    {
+      resourcePath: '/socialActions/{actionUrn}/comments/{commentId}',
+      pathKeys: {
+        actionUrn: 'urn:li:share:123',
+        commentId: 'foobar123'
+      },
+      versionString: '202209',
+      expectedUrl:
+        'https://api.linkedin.com/rest/socialActions/urn%3Ali%3Ashare%3A123/comments/foobar123'
+    },
+    {
+      resourcePath: '/testResource/{complexKey}',
+      pathKeys: {
+        complexKey: { member: 'urn:li:member:123', account: 'urn:li:account:456' }
+      },
+      expectedUrl:
+        'https://api.linkedin.com/v2/testResource/(member:urn%3Ali%3Amember%3A123,account:urn%3Ali%3Aaccount%3A456)'
+    }
+  ])('buildRestliUrl', ({ resourcePath, pathKeys, versionString, expectedUrl }) => {
+    expect(buildRestliUrl(resourcePath, pathKeys, versionString)).toBe(expectedUrl);
   });
 
   test('getRestliRequestHeaders', () => {


### PR DESCRIPTION
- updated rest.li client to use resourcePath with path key placeholders, which is easier to use for sub-resources
- updated batchFinder method to explicitly require a finderCriteria argument