### PR TITLE
Add the types for id_token and token_type for openid scope

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -32,6 +32,10 @@ export interface AccessToken3LResponse {
   refresh_token_expires_in?: number;
   /** A comma-separated list of scopes authorized by the member (e.g. "r_liteprofile,r_ads") */
   scope: string;
+  /** returned when the `openid` scope is sepecified A JSON Web Token (JWT). */
+  id_token?: string;
+  /** usually a `Bearer` token */
+  token_type?: string;
 }
 
 enum TokenAuthType {


### PR DESCRIPTION
Based on the MS [documentation](https://learn.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin-v2?context=linkedin%2Fconsumer%2Fcontext#retrieving-member-profiles-using-id-tokens)

when we perform a successful 3 legged OAuth with `openid` and `profile` scopes, the api will return the `id_token` and `token_type` properties.

I noticed that this was missing from the library, hence the PR

Thanks